### PR TITLE
Feature/allow so library and prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+.qmake.stash
+Makefile
+scintilla/bin-x86/
+scintilla/lib/
+scintilla/qt/ScintillaEditBase/*.o
+scintilla/qt/ScintillaEditBase/moc_*
+scite/qt/*.o
+scite/qt/config.h
+scite/qt/moc_*
+scite/qt/qrc_sciteqt.cpp
+scite/qt/sciteqt
+sciteqt.pro.user

--- a/config.pri
+++ b/config.pri
@@ -1,0 +1,5 @@
+PREFIX = $$PREFIX
+isEmpty(PREFIX) {
+    PREFIX = /usr/local
+}
+

--- a/scintilla/qt/ScintillaEditBase/ScintillaEditBase.pro
+++ b/scintilla/qt/ScintillaEditBase/ScintillaEditBase.pro
@@ -167,10 +167,22 @@ CONFIG(release, debug|release) {
 }
 
 small {
+    CONFIG += compile_libtool create_libtool
+    CONFIG += create_pc create_prl no_install_prl
+
     DESTDIR = ../../lib
     header_files.path = $${PREFIX}/include/QuickScintillaEditBase
     header_files.files = $$HEADERS
     target.path = $${PREFIX}/lib
+
+    QMAKE_PKGCONFIG_FILE = $${TARGET}
+    QMAKE_PKGCONFIG_NAME = $${TARGET}
+    QMAKE_PKGCONFIG_DESCRIPTION = A QML version of QScintilla
+    QMAKE_PKGCONFIG_LIBDIR = $$target.path
+    QMAKE_PKGCONFIG_INCDIR = $$header_files.path
+    QMAKE_PKGCONFIG_DESTDIR = pkgconfig
+    QMAKE_PKGCONFIG_PREFIX = $${PREFIX}
+    QMAKE_PKGCONFIG_VERSION = 1.0
 
     INSTALLS += header_files target
 }

--- a/scintilla/qt/ScintillaEditBase/ScintillaEditBase.pro
+++ b/scintilla/qt/ScintillaEditBase/ScintillaEditBase.pro
@@ -135,9 +135,15 @@ HEADERS  += \
     ../../src/CaseConvert.h \
     ../../src/CallTip.h \
     ../../src/AutoComplete.h \
+    ../../src/Position.h \
+    ../../src/UniqueString.h \
+    ../../src/EditModel.h \
+    ../../src/MarginView.h \
+    ../../src/EditView.h \
     ../../include/Scintilla.h \
     ../../include/SciLexer.h \
     ../../include/Platform.h \
+    ../../include/ILoader.h \
     ../../include/ILexer.h \
     ../../include/Sci_Position.h \
     ../../lexlib/WordList.h \

--- a/scintilla/qt/ScintillaEditBase/ScintillaEditBase.pro
+++ b/scintilla/qt/ScintillaEditBase/ScintillaEditBase.pro
@@ -1,3 +1,5 @@
+include(../../../config.pri)
+
 #-------------------------------------------------
 #
 # Project created by QtCreator 2011-05-05T12:41:23
@@ -7,10 +9,21 @@
 QT       += qml quick core gui
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
-TARGET = ScintillaEditBase
+!small {
+    TARGET = ScintillaEditBase
+}
+
+small {
+    TARGET = QuickScintillaEditBase
+}
+
 TEMPLATE = lib
 #CONFIG += lib_bundle
-CONFIG += staticlib
+
+!small {
+    CONFIG += staticlib
+}
+
 CONFIG += c++1z
 
 VERSION = 4.4.6
@@ -149,7 +162,18 @@ CONFIG(release, debug|release) {
     DEFINES += NDEBUG=1
 }
 
-DESTDIR = ../../bin-$${ARCH_PATH}
+!small {
+    DESTDIR = ../../bin-$${ARCH_PATH}
+}
+
+small {
+    DESTDIR = ../../lib
+    header_files.path = $${PREFIX}/include/QuickScintillaEditBase
+    header_files.files = $$HEADERS
+    target.path = $${PREFIX}/lib
+
+    INSTALLS += header_files target
+}
 
 macx {
 	QMAKE_LFLAGS_SONAME = -Wl,-install_name,@executable_path/../Frameworks/

--- a/scintilla/qt/ScintillaEditBase/ScintillaEditBase.pro
+++ b/scintilla/qt/ScintillaEditBase/ScintillaEditBase.pro
@@ -190,6 +190,7 @@ small {
     QMAKE_PKGCONFIG_DESTDIR = pkgconfig
     QMAKE_PKGCONFIG_PREFIX = $${PREFIX}
     QMAKE_PKGCONFIG_VERSION = 1.0
+    QMAKE_PKGCONFIG_CFLAGS = -DQT_QML
 
     INSTALLS += header_files target
 }

--- a/scintilla/qt/ScintillaEditBase/ScintillaEditBase.pro
+++ b/scintilla/qt/ScintillaEditBase/ScintillaEditBase.pro
@@ -139,6 +139,7 @@ HEADERS  += \
     ../../include/SciLexer.h \
     ../../include/Platform.h \
     ../../include/ILexer.h \
+    ../../include/Sci_Position.h \
     ../../lexlib/WordList.h \
     ../../lexlib/StyleContext.h \
     ../../lexlib/SparseState.h \

--- a/scite/qt/config.h.in
+++ b/scite/qt/config.h.in
@@ -1,0 +1,6 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#define INSTALL_PREFIX	'"$$PREFIX"'
+
+#endif // CONFIG_H

--- a/scite/qt/qt.pro
+++ b/scite/qt/qt.pro
@@ -1,3 +1,5 @@
+include(../../config.pri)
+
 QT += qml quick quickcontrols2 widgets printsupport svg
 
 android {
@@ -9,6 +11,8 @@ TARGET = sciteqt
 DEFINES += QT_QML
 
 CONFIG += c++1z
+
+QMAKE_SUBSTITUTES += config.h.in
 
 wasm {
     QMAKE_CXXFLAGS += "-s ASYNCIFY=1 -s ASSERTIONS=1"
@@ -174,16 +178,16 @@ win32 {
 }
 
 unix {
-    target.path = /usr/local/bin
+    target.path = $${PREFIX}/bin
     INSTALLS += target
 
-    properties.path = /usr/share/sciteqt
+    properties.path = $${PREFIX}/share/sciteqt
     properties.files += ./SciTEUser.properties
     properties.files += ./SciTEGlobal.properties
     properties.files += ../src/SciTE.properties
     properties.files += ../src/abbrev.properties
 
-    localisations.path = /usr/share/sciteqt/localisations
+    localisations.path = $${PREFIX}/share/sciteqt/localisations
     localisations.files += translations/locale.de.properties
     localisations.files += translations/locale.nl.properties
     localisations.files += translations/locale.fr.properties
@@ -537,7 +541,14 @@ ANDROID_PACKAGE_SOURCE_DIR = $$PWD/android
 ANDROID_ABIS = armeabi-v7a arm64-v8a x86 x86_64
 #ANDROID_ABIS = arm64-v8a
 
-LIBS += -L$$OUT_PWD/../../scintilla/bin-$${ARCH_PATH}/ -lScintillaEditBase
+!small {
+    #LIBS += -L$$OUT_PWD/../../scintilla/bin-$${ARCH_PATH}/ -lScintillaEditBase
+    LIBS += -L$$OUT_PWD/../../scintilla/lib -lQuickScintillaEditBase
+}
+
+small {
+    LIBS += -L$$OUT_PWD/../../scintilla/lib -lQuickScintillaEditBase
+}
 
 android {
     LIBS += -L$$OUT_PWD/../../CppLispInterpreter/bin-$${ARCH_PATH}/ -lFuelInterpreter

--- a/scite/qt/qt.pro
+++ b/scite/qt/qt.pro
@@ -542,8 +542,7 @@ ANDROID_ABIS = armeabi-v7a arm64-v8a x86 x86_64
 #ANDROID_ABIS = arm64-v8a
 
 !small {
-    #LIBS += -L$$OUT_PWD/../../scintilla/bin-$${ARCH_PATH}/ -lScintillaEditBase
-    LIBS += -L$$OUT_PWD/../../scintilla/lib -lQuickScintillaEditBase
+    LIBS += -L$$OUT_PWD/../../scintilla/bin-$${ARCH_PATH}/ -lScintillaEditBase
 }
 
 small {

--- a/scite/qt/sciteqt.cpp
+++ b/scite/qt/sciteqt.cpp
@@ -44,6 +44,8 @@
 
 #include "sciteqtenvironmentforjavascript.h"
 
+#include "config.h"
+
 #ifdef Q_OS_WASM
 #include <emscripten.h>
 #endif
@@ -639,7 +641,8 @@ FilePath GetSciTEPath(const QByteArray & home)
 #elif defined(Q_OS_ANDROID)
         strcpy(buf,FILES_DIR);
 #elif defined(Q_OS_UNIX)
-        strcpy(buf,QDir::toNativeSeparators("/usr/share/sciteqt").toStdString().c_str());
+        QString sharedPath = QString(INSTALL_PREFIX) + QString("/share/sciteqt");
+        strcpy(buf,QDir::toNativeSeparators(sharedPath).toStdString().c_str());
 #else
         //QString dataDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);    // -> /usr/share/ + sciteqt/...
         //strcpy(buf,QDir::toNativeSeparators(dataDir).toStdString().c_str());

--- a/sciteqt.pro
+++ b/sciteqt.pro
@@ -1,11 +1,18 @@
-TEMPLATE 	= subdirs
+include(config.pri)
 
-SUBDIRS		= scintilla/qt/ScintillaEditBase scite/qt
+TEMPLATE 	= subdirs
+SUBDIRS		= scintilla/qt/ScintillaEditBase
+
+#!small {
+    SUBDIRS         += scite/qt
+#}
+
 android {
     SUBDIRS	+= CppLispInterpreter/CppLispInterpreter.pro
 }
 
 scite/qt.depends = scintilla/qt/ScintillaEditBase
+
 android {
     scite/qt.depends = CppLispInterpreter/CppLispInterpreter.pro
 }


### PR DESCRIPTION
Hello Michael,

My name is Philip and I work for a company in Traunreut that develops controls for CNC machines. We are working on the so called TNC7 (https://news.heidenhain.com/machine-tool/tnc7) control. I hope my project manager will further introduce Heidenhain at some point to you.

We want to build-in an editor component and we noticed that you did some very interesting work to bringing the QScintilla component to the world of QML. The TNC7 uses QML so that makes it very interesting to us.

We would like to utilize the editing component as a (non-static) library, with its headers installed and maybe also a pkg-config .pc file installed.

I started making some changes to your qmake .pro files to make this possible for us.

My best guess is that you'll have many suggestions to how you want it to be. I'm of course interested in those comments so that I can adapt. I obviously would prefer this to go upstream to your master and/or into your releases.

Some things that we need:
* a UNIX style PREFIX that can be passed at qmake command line
* Installed headers
* A installed .pri or a installed pkg-config .pc file
* The component itself as .so file in prefix/lib
* The possibility not to build scite/qt
* Generally making it possible to make a RPM package (versioning, etc)
